### PR TITLE
Add LocalizerDirection op mode to debug odometry hardware installation

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/pedroPathing/LOCALIZATION.md
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/pedroPathing/LOCALIZATION.md
@@ -28,6 +28,7 @@ that applies to you and follow the directions there.
 * Then, go to `DriveEncoderLocalizer.java`. The motor names are already set, so you don't have to do
   anything to change the encoder names there.
 * Then, reverse the direction of any encoders so that all encoders tick up when the robot is moving forward.
+ Confirm this by using the `Localizer Direction` op mode.
 * Now, you'll have to tune the multipliers. These convert your measurements from encoder ticks into 
   inches or radians, essentially scaling your localizer so that your numbers are accurate to the real
   world.
@@ -78,6 +79,7 @@ that applies to you and follow the directions there.
   of your robot's.
 * Then, reverse the direction of any encoders so that the forward encoder ticks up when the robot
  is moving forward and the strafe encoder ticks up when the robot moves right.
+ Confirm this by using the `Localizer Direction` op mode.
 * Now, you'll have to tune the multipliers. These convert your measurements from encoder ticks into
   inches or radians, essentially scaling your localizer so that your numbers are accurate to the real
   world.
@@ -117,6 +119,7 @@ that applies to you and follow the directions there.
   variable names correspond to which tracking wheel should be connected.
 * Then, reverse the direction of any encoders so that the forward encoders tick up when the robot
   is moving forward and the strafe encoder ticks up when the robot moves right.
+ Confirm this by using the `Localizer Direction` op mode.
 * First, start with the `Turn Localizer Tuner`. You'll want to position your robot to be facing
   in a direction you can easily find again, like lining up an edge of the robot against a field tile edge.
   By default, you should spin the robot for one rotation going counterclockwise. Once you've spun
@@ -163,6 +166,7 @@ that applies to you and follow the directions there.
   of your robot's.
 * Then, reverse the direction of any encoders so that the forward encoders tick up when the robot
   is moving forward and the strafe encoder ticks up when the robot moves right.
+ Confirm this by using the `Localizer Direction` op mode.
 * Although heading localization is done mostly through the IMU, the tracking wheels are still used for
   small angle adjustments for better stability. So, you will still need to tune your turning multiplier.
 * First, start with the `Turn Localizer Tuner`. Before doing any tuning, go to FTC Dashboard and find
@@ -207,6 +211,7 @@ that applies to you and follow the directions there.
 * Next, enter in the position of your OTOS relative to the center of the wheels of the robot. The
   positions are in inches, so convert measurements accordingly. Use the comment above the class
   declaration as well as to help you with the coordinates.
+* Confirm that your OTOS sensor is returning valid position data by using the `Localizer Direction` op mode.
 * First, start with the `Turn Localizer Tuner`. You'll want to position your robot to be facing
   in a direction you can easily find again, like lining up an edge of the robot against a field tile edge.
   By default, you should spin the robot for one rotation going counterclockwise. Once you've spun
@@ -248,6 +253,7 @@ that applies to you and follow the directions there.
 * Then, go to the `PinpointLocalier.java` file and go to where it tells you to replace
   the current statement with your pinpoint port in the constructor. Replace the `deviceName` parameter
   with the name of the port that the pinpoint is connected to.
+* Confirm that your Pinpoint is returning valid position data using the `Localizer Direction` op mode.
 * Next, follow the instructions left by the TODO: comment and enter in the odometry measurements either in
   mms or inches (We have the conversion rates listed).
 * First, to ensure that your pinpoint is properly connected, please run the `SensorGoBildaPinpointExample.java`

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/pedroPathing/LOCALIZATION.md
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/pedroPathing/LOCALIZATION.md
@@ -59,7 +59,8 @@ that applies to you and follow the directions there.
   replace `STRAFE_TICKS_TO_INCHES` in the localizer with your multiplier. Make sure you replace the number,
   not add on or multiply it to the previous number. The tuner takes into account your current multiplier.
 * Once you're done with all this, your localizer should be tuned. To test it out, you can go to
- `Localization Test` and push around or drive around your robot. Go to [FTC Dashboard](http://192.168.43.1:8080/dash)
+ `Localization Test` and push around or drive around your robot (make sure to set the motor names in
+ `FollowerConstants` and to reverse the motors properly in `LocalizationTest`). Go to [FTC Dashboard](http://192.168.43.1:8080/dash)
  and on the top right, switch the drop down from the default view to the field view. Then, on the bottom
  left corner, you should see a field and the robot being drawn on the field. You can then move your
  robot around and see if the movements look accurate on FTC Dashboard. If they don't, then you'll
@@ -102,7 +103,8 @@ that applies to you and follow the directions there.
   replace `STRAFE_TICKS_TO_INCHES` in the localizer with your multiplier. Make sure you replace the number,
   not add on or multiply it to the previous number. The tuner takes into account your current multiplier.
 * Once you're done with all this, your localizer should be tuned. To test it out, you can go to
- `Localization Test` and push around or drive around your robot. Go to [FTC Dashboard](http://192.168.43.1:8080/dash)
+ `Localization Test` and push around or drive around your robot (make sure to set the motor names in
+ `FollowerConstants` and to reverse the motors properly in `LocalizationTest`). Go to [FTC Dashboard](http://192.168.43.1:8080/dash)
  and on the top right, switch the drop down from the default view to the field view. Then, on the bottom
  left corner, you should see a field and the robot being drawn on the field. You can then move your
  robot around and see if the movements look accurate on FTC Dashboard. If they don't, then you'll
@@ -147,7 +149,8 @@ that applies to you and follow the directions there.
   replace `STRAFE_TICKS_TO_INCHES` in the localizer with your multiplier. Make sure you replace the number,
   not add on or multiply it to the previous number. The tuner takes into account your current multiplier.
 * Once you're done with all this, your localizer should be tuned. To test it out, you can go to
-  `Localization Test` and push around or drive around your robot. Go to [FTC Dashboard](http://192.168.43.1:8080/dash)
+  `Localization Test` and push around or drive around your robot (make sure to set the motor names in
+  `FollowerConstants` and to reverse the motors properly in `LocalizationTest`). Go to [FTC Dashboard](http://192.168.43.1:8080/dash)
   and on the top right, switch the drop down from the default view to the field view. Then, on the bottom
   left corner, you should see a field and the robot being drawn on the field. You can then move your
   robot around and see if the movements look accurate on FTC Dashboard. If they don't, then you'll
@@ -197,7 +200,8 @@ that applies to you and follow the directions there.
   replace `STRAFE_TICKS_TO_INCHES` in the localizer with your multiplier. Make sure you replace the number,
   not add on or multiply it to the previous number. The tuner takes into account your current multiplier.
 * Once you're done with all this, your localizer should be tuned. Make sure that `useIMU` is turned back on. To test it out, you can go to
-  `Localization Test` and push around or drive around your robot. Go to [FTC Dashboard](http://192.168.43.1:8080/dash)
+  `Localization Test` and push around or drive around your robot (make sure to set the motor names in
+  `FollowerConstants` and to reverse the motors properly in `LocalizationTest`). Go to [FTC Dashboard](http://192.168.43.1:8080/dash)
   and on the top right, switch the drop down from the default view to the field view. Then, on the bottom
   left corner, you should see a field and the robot being drawn on the field. You can then move your
   robot around and see if the movements look accurate on FTC Dashboard. If they don't, then you'll
@@ -241,7 +245,8 @@ that applies to you and follow the directions there.
   replace the linear scalar on line `77` in the localizer with your scalar. Make sure you replace the number,
   not add on or multiply it to the previous number. The tuner takes into account your current scalar.
 * Once you're done with all this, your localizer should be tuned. To test it out, you can go to
-  `Localization Test` and push around or drive around your robot. Go to [FTC Dashboard](http://192.168.43.1:8080/dash)
+  `Localization Test` and push around or drive around your robot (make sure to set the motor names in
+  `FollowerConstants` and to reverse the motors properly in `LocalizationTest`). Go to [FTC Dashboard](http://192.168.43.1:8080/dash)
   and on the top right, switch the drop down from the default view to the field view. Then, on the bottom
   left corner, you should see a field and the robot being drawn on the field. You can then move your
   robot around and see if the movements look accurate on FTC Dashboard. If they don't, then you'll
@@ -259,7 +264,8 @@ that applies to you and follow the directions there.
 * First, to ensure that your pinpoint is properly connected, please run the `SensorGoBildaPinpointExample.java`
   file left in the `tuning` folder located within `localization`.
 * Once completed, the localizer should be properly tuned. To test it out, you can go to
-  `Localization Test` and push around or drive around your robot. Go to [FTC Dashboard](http://192.168.43.1:8080/dash)
+  `Localization Test` and push around or drive around your robot (make sure to set the motor names in
+  `FollowerConstants` and to reverse the motors properly in `LocalizationTest`). Go to [FTC Dashboard](http://192.168.43.1:8080/dash)
   and on the top right, switch the drop down from the default view to the field view. Then, on the bottom
   left corner, you should see a field and the robot being drawn on the field. You can then move your
   robot around and see if the movements look accurate on FTC Dashboard. If they don't, then you'll

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/pedroPathing/localization/Encoder.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/pedroPathing/localization/Encoder.java
@@ -80,4 +80,14 @@ public class Encoder {
     public double getDeltaPosition() {
         return getMultiplier() * (currentPosition - previousPosition);
     }
+
+    /**
+     * Returns the current position of the encoder, taking into the account the direction.
+     * Useful to debugging the direction of the encoder.
+     *
+     * @return The current position
+     */
+    public double getCurrentPosition() {
+        return getMultiplier() * currentPosition;
+    }
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/pedroPathing/localization/Localizer.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/pedroPathing/localization/Localizer.java
@@ -2,6 +2,7 @@ package org.firstinspires.ftc.teamcode.pedroPathing.localization;
 
 import com.qualcomm.robotcore.hardware.IMU;
 
+import org.firstinspires.ftc.robotcore.external.Telemetry;
 import org.firstinspires.ftc.teamcode.pedroPathing.pathGeneration.Vector;
 
 /**
@@ -102,4 +103,11 @@ public abstract class Localizer {
     public IMU getIMU() {
         return null;
     }
+
+
+    /**
+     * Send values used by this localizer to telemetry to check that the direction is set correctly.
+     * @param telemetry The Telemetry object
+     */
+    public void debug(Telemetry telemetry) {}
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/pedroPathing/localization/PoseUpdater.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/pedroPathing/localization/PoseUpdater.java
@@ -4,6 +4,7 @@ import com.qualcomm.hardware.lynx.LynxModule;
 import com.qualcomm.robotcore.hardware.HardwareMap;
 import com.qualcomm.robotcore.hardware.IMU;
 
+import org.firstinspires.ftc.robotcore.external.Telemetry;
 import org.firstinspires.ftc.robotcore.external.navigation.AngleUnit;
 import org.firstinspires.ftc.teamcode.pedroPathing.localization.localizers.ThreeWheelIMULocalizer;
 import org.firstinspires.ftc.teamcode.pedroPathing.localization.localizers.ThreeWheelLocalizer;
@@ -353,5 +354,9 @@ public class PoseUpdater {
      */
     public void resetIMU() {
         localizer.resetIMU();
+    }
+
+    public void debug(Telemetry telemetry) {
+        localizer.debug(telemetry);
     }
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/pedroPathing/localization/localizers/DriveEncoderLocalizer.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/pedroPathing/localization/localizers/DriveEncoderLocalizer.java
@@ -9,6 +9,7 @@ import com.acmerobotics.dashboard.config.Config;
 import com.qualcomm.robotcore.hardware.DcMotorEx;
 import com.qualcomm.robotcore.hardware.HardwareMap;
 
+import org.firstinspires.ftc.robotcore.external.Telemetry;
 import org.firstinspires.ftc.teamcode.pedroPathing.localization.Encoder;
 import org.firstinspires.ftc.teamcode.pedroPathing.localization.Localizer;
 import org.firstinspires.ftc.teamcode.pedroPathing.localization.Matrix;
@@ -268,5 +269,17 @@ public class DriveEncoderLocalizer extends Localizer {
      * This does nothing since this localizer does not use the IMU.
      */
     public void resetIMU() {
+    }
+
+    /**
+     * Send all the motor encoder positions.
+     *
+     * @param telemetry The Telemetry object
+     */
+    public void debug(Telemetry telemetry) {
+        telemetry.addData("leftFront", leftFront.getCurrentPosition());
+        telemetry.addData("leftRear", leftRear.getCurrentPosition());
+        telemetry.addData("rightFront", rightFront.getCurrentPosition());
+        telemetry.addData("rightRear", rightRear.getCurrentPosition());
     }
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/pedroPathing/localization/localizers/OTOSLocalizer.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/pedroPathing/localization/localizers/OTOSLocalizer.java
@@ -3,6 +3,7 @@ package org.firstinspires.ftc.teamcode.pedroPathing.localization.localizers;
 import com.qualcomm.hardware.sparkfun.SparkFunOTOS;
 import com.qualcomm.robotcore.hardware.HardwareMap;
 
+import org.firstinspires.ftc.robotcore.external.Telemetry;
 import org.firstinspires.ftc.robotcore.external.navigation.AngleUnit;
 import org.firstinspires.ftc.robotcore.external.navigation.DistanceUnit;
 import org.firstinspires.ftc.teamcode.pedroPathing.localization.Localizer;
@@ -221,5 +222,18 @@ public class OTOSLocalizer extends Localizer {
      * This does nothing since this localizer does not use the IMU.
      */
     public void resetIMU() {
+    }
+
+    /**
+     * Send the raw OTOS position.
+     *
+     * @param telemetry The Telemetry object
+     */
+    public void debug(Telemetry telemetry) {
+        SparkFunOTOS.Pose2D rawPose = otos.getPosition();
+        Pose pose = new Pose(rawPose.x, rawPose.y, rawPose.h);
+        telemetry.addData("raw x", rawPose.x);
+        telemetry.addData("raw y", rawPose.y);
+        telemetry.addData("raw heading", rawPose.h);
     }
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/pedroPathing/localization/localizers/PinpointLocalizer.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/pedroPathing/localization/localizers/PinpointLocalizer.java
@@ -3,6 +3,7 @@ package org.firstinspires.ftc.teamcode.pedroPathing.localization.localizers;
 
 import com.qualcomm.robotcore.hardware.HardwareMap;
 
+import org.firstinspires.ftc.robotcore.external.Telemetry;
 import org.firstinspires.ftc.robotcore.external.navigation.AngleUnit;
 import org.firstinspires.ftc.robotcore.external.navigation.DistanceUnit;
 import org.firstinspires.ftc.robotcore.external.navigation.Pose2D;
@@ -207,5 +208,17 @@ public class PinpointLocalizer extends Localizer {
      */
     public void resetPinpoint(){
         odo.resetPosAndIMU();
+    }
+
+    /**
+     * Send the raw Pinpoint location.
+     *
+     * @param telemetry The Telemetry object
+     */
+    public void debug(Telemetry telemetry) {
+        Pose2D rawPose = odo.getPosition();
+        telemetry.addData("raw x", rawPose.getX(DistanceUnit.INCH));
+        telemetry.addData("raw y", rawPose.getY(DistanceUnit.INCH));
+        telemetry.addData("raw heading", rawPose.getHeading(AngleUnit.RADIANS));
     }
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/pedroPathing/localization/localizers/ThreeWheelIMULocalizer.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/pedroPathing/localization/localizers/ThreeWheelIMULocalizer.java
@@ -6,6 +6,7 @@ import com.qualcomm.robotcore.hardware.DcMotorEx;
 import com.qualcomm.robotcore.hardware.HardwareMap;
 import com.qualcomm.robotcore.hardware.IMU;
 
+import org.firstinspires.ftc.robotcore.external.Telemetry;
 import org.firstinspires.ftc.robotcore.external.navigation.AngleUnit;
 import org.firstinspires.ftc.teamcode.pedroPathing.localization.Encoder;
 import org.firstinspires.ftc.teamcode.pedroPathing.localization.Localizer;
@@ -322,5 +323,17 @@ public class ThreeWheelIMULocalizer extends Localizer {
     @Override
     public IMU getIMU() {
         return imu;
+    }
+
+    /**
+     * Send the yaw and the 3 encoder positions.
+     *
+     * @param telemetry The Telemetry object
+     */
+    public void debug(Telemetry telemetry) {
+        telemetry.addData("yaw", imu.getRobotYawPitchRollAngles().getYaw(AngleUnit.RADIANS));
+        telemetry.addData("leftEncoder", leftEncoder.getCurrentPosition());
+        telemetry.addData("rightEncoder", rightEncoder.getCurrentPosition());
+        telemetry.addData("strafeEncoder", strafeEncoder.getCurrentPosition());
     }
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/pedroPathing/localization/localizers/ThreeWheelLocalizer.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/pedroPathing/localization/localizers/ThreeWheelLocalizer.java
@@ -4,6 +4,7 @@ import com.acmerobotics.dashboard.config.Config;
 import com.qualcomm.robotcore.hardware.DcMotorEx;
 import com.qualcomm.robotcore.hardware.HardwareMap;
 
+import org.firstinspires.ftc.robotcore.external.Telemetry;
 import org.firstinspires.ftc.teamcode.pedroPathing.localization.Encoder;
 import org.firstinspires.ftc.teamcode.pedroPathing.localization.Localizer;
 import org.firstinspires.ftc.teamcode.pedroPathing.localization.Matrix;
@@ -288,5 +289,16 @@ public class ThreeWheelLocalizer extends Localizer {
      * This does nothing since this localizer does not use the IMU.
      */
     public void resetIMU() {
+    }
+
+    /**
+     * Send the 3 encoder positions.
+     *
+     * @param telemetry The Telemetry object
+     */
+    public void debug(Telemetry telemetry) {
+        telemetry.addData("leftEncoder", leftEncoder.getCurrentPosition());
+        telemetry.addData("rightEncoder", rightEncoder.getCurrentPosition());
+        telemetry.addData("strafeEncoder", strafeEncoder.getCurrentPosition());
     }
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/pedroPathing/localization/localizers/TwoWheelLocalizer.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/pedroPathing/localization/localizers/TwoWheelLocalizer.java
@@ -6,6 +6,7 @@ import com.qualcomm.robotcore.hardware.DcMotorEx;
 import com.qualcomm.robotcore.hardware.HardwareMap;
 import com.qualcomm.robotcore.hardware.IMU;
 
+import org.firstinspires.ftc.robotcore.external.Telemetry;
 import org.firstinspires.ftc.robotcore.external.navigation.AngleUnit;
 import org.firstinspires.ftc.teamcode.pedroPathing.localization.Encoder;
 import org.firstinspires.ftc.teamcode.pedroPathing.localization.Localizer;
@@ -305,5 +306,16 @@ public class TwoWheelLocalizer extends Localizer { // todo: make two wheel odo w
     @Override
     public IMU getIMU() {
         return imu;
+    }
+
+    /**
+     * Send the yaw and the 2 encoder positions.
+     *
+     * @param telemetry The Telemetry object
+     */
+    public void debug(Telemetry telemetry) {
+        telemetry.addData("yaw", imu.getRobotYawPitchRollAngles().getYaw(AngleUnit.RADIANS));
+        telemetry.addData("forwardEncoder", forwardEncoder.getCurrentPosition());
+        telemetry.addData("strafeEncoder", strafeEncoder.getCurrentPosition());
     }
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/pedroPathing/localization/tuning/ForwardTuner.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/pedroPathing/localization/tuning/ForwardTuner.java
@@ -19,7 +19,7 @@ import org.firstinspires.ftc.teamcode.pedroPathing.util.Drawing;
  * at the end of the distance, record the ticks to inches multiplier. Feel free to run multiple trials
  * and average the results. Then, input the multiplier into the forward ticks to inches in your
  * localizer of choice.
- * You can adjust the target distance on FTC Dashboard: 192/168/43/1:8080/dash
+ * You can adjust the target distance on FTC Dashboard: http://192.168.43.1:8080/dash
  *
  * @author Anyi Lin - 10158 Scott's Bots
  * @version 1.0, 5/6/2024

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/pedroPathing/localization/tuning/LateralTuner.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/pedroPathing/localization/tuning/LateralTuner.java
@@ -20,7 +20,7 @@ import org.firstinspires.ftc.teamcode.pedroPathing.util.Drawing;
  * at the end of the distance, record the ticks to inches multiplier. Feel free to run multiple trials
  * and average the results. Then, input the multiplier into the strafe ticks to inches in your
  * localizer of choice.
- * You can adjust the target distance on FTC Dashboard: 192/168/43/1:8080/dash
+ * You can adjust the target distance on FTC Dashboard: http://192.168.43.1:8080/dash
  *
  * @author Anyi Lin - 10158 Scott's Bots
  * @version 1.0, 5/6/2024

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/pedroPathing/localization/tuning/LocalizationTest.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/pedroPathing/localization/tuning/LocalizationTest.java
@@ -26,7 +26,7 @@ import java.util.List;
 /**
  * This is the LocalizationTest OpMode. This is basically just a simple mecanum drive attached to a
  * PoseUpdater. The OpMode will print out the robot's pose to telemetry as well as draw the robot
- * on FTC Dashboard (192/168/43/1:8080/dash). You should use this to check the robot's localization.
+ * on FTC Dashboard (http://192.168.43.1:8080/dash). You should use this to check the robot's localization.
  *
  * @author Anyi Lin - 10158 Scott's Bots
  * @version 1.0, 5/6/2024

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/pedroPathing/localization/tuning/LocalizerDirection.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/pedroPathing/localization/tuning/LocalizerDirection.java
@@ -1,0 +1,50 @@
+package org.firstinspires.ftc.teamcode.pedroPathing.localization.tuning;
+
+import com.acmerobotics.dashboard.FtcDashboard;
+import com.acmerobotics.dashboard.config.Config;
+import com.acmerobotics.dashboard.telemetry.MultipleTelemetry;
+import com.qualcomm.robotcore.eventloop.opmode.OpMode;
+import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
+
+import org.firstinspires.ftc.robotcore.external.Telemetry;
+import org.firstinspires.ftc.teamcode.pedroPathing.localization.PoseUpdater;
+
+/**
+ * This is the LocalizerDirection OpMode. This allows you to check if the encoders
+ * used in your localizer have the correct direction.
+ *
+ * @author Julien Vanier - 21615 Rocket Robotics
+ * @version 1.0, 5/6/2024
+ */
+@Config
+@TeleOp(group = "Pedro Pathing Tuning", name = "Localizer Direction")
+public class LocalizerDirection extends OpMode {
+    private PoseUpdater poseUpdater;
+    private Telemetry telemetryA;
+
+    /**
+     * This initializes the PoseUpdater and the FTC Dashboard telemetry.
+     */
+    @Override
+    public void init() {
+        poseUpdater = new PoseUpdater(hardwareMap);
+
+        telemetryA = new MultipleTelemetry(this.telemetry, FtcDashboard.getInstance().getTelemetry());
+        telemetryA.addLine("This will print the encoder ticks on telemetry.");
+        telemetryA.addLine("Forward encoders should increase when pushing the robot forward.");
+        telemetryA.addLine("Strafe encoder should increase when pushing the robot right.");
+        telemetryA.addLine("Yaw should go from 0 to 3.14 when the robot does half a turn counter-clockwise.");
+        telemetryA.update();
+    }
+
+    /**
+     * This updates the robot's pose estimate and send telemetry.
+     */
+    @Override
+    public void loop() {
+        poseUpdater.update();
+
+        poseUpdater.debug(telemetryA);
+        telemetryA.update();
+    }
+}

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/pedroPathing/localization/tuning/TurnTuner.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/pedroPathing/localization/tuning/TurnTuner.java
@@ -20,7 +20,7 @@ import org.firstinspires.ftc.teamcode.pedroPathing.util.Drawing;
  * When you're at the end of the angle, record the ticks to inches multiplier. Feel free to run
  * multiple trials and average the results. Then, input the multiplier into the turning ticks to
  * radians in your localizer of choice.
- * You can adjust the target angle on FTC Dashboard: 192/168/43/1:8080/dash
+ * You can adjust the target angle on FTC Dashboard: http://192.168.43.1:8080/dash
  *
  * @author Anyi Lin - 10158 Scott's Bots
  * @version 1.0, 5/6/2024

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/pedroPathing/tuning/ForwardVelocityTuner.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/pedroPathing/tuning/ForwardVelocityTuner.java
@@ -32,7 +32,7 @@ import java.util.List;
  * is, when paired with StrafeVelocityTuner, allows FollowerConstants to create a Vector that
  * empirically represents the direction your mecanum wheels actually prefer to go in, allowing for
  * more accurate following.
- * You can adjust the distance the robot will travel on FTC Dashboard: 192/168/43/1:8080/dash
+ * You can adjust the distance the robot will travel on FTC Dashboard: http://192.168.43.1:8080/dash
  *
  * @author Anyi Lin - 10158 Scott's Bots
  * @author Aaron Yang - 10158 Scott's Bots

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/pedroPathing/tuning/ForwardZeroPowerAccelerationTuner.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/pedroPathing/tuning/ForwardZeroPowerAccelerationTuner.java
@@ -32,7 +32,7 @@ import java.util.List;
  * that number is then printed. This is used to determine how the robot will decelerate in the
  * forward direction when power is cut, making the estimations used in the calculations for the
  * drive Vector more accurate and giving better braking at the end of Paths.
- * You can adjust the max velocity the robot will hit on FTC Dashboard: 192/168/43/1:8080/dash
+ * You can adjust the max velocity the robot will hit on FTC Dashboard: http://192.168.43.1:8080/dash
  *
  * @author Anyi Lin - 10158 Scott's Bots
  * @author Aaron Yang - 10158 Scott's Bots

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/pedroPathing/tuning/LateralZeroPowerAccelerationTuner.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/pedroPathing/tuning/LateralZeroPowerAccelerationTuner.java
@@ -32,7 +32,7 @@ import java.util.List;
  * that number is then printed. This is used to determine how the robot will decelerate in the
  * forward direction when power is cut, making the estimations used in the calculations for the
  * drive Vector more accurate and giving better braking at the end of Paths.
- * You can adjust the max velocity the robot will hit on FTC Dashboard: 192/168/43/1:8080/dash
+ * You can adjust the max velocity the robot will hit on FTC Dashboard: http://192.168.43.1:8080/dash
  *
  * @author Anyi Lin - 10158 Scott's Bots
  * @author Aaron Yang - 10158 Scott's Bots

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/pedroPathing/tuning/StrafeVelocityTuner.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/pedroPathing/tuning/StrafeVelocityTuner.java
@@ -32,7 +32,7 @@ import java.util.List;
  * is, when paired with ForwardVelocityTuner, allows FollowerConstants to create a Vector that
  * empirically represents the direction your mecanum wheels actually prefer to go in, allowing for
  * more accurate following.
- * You can adjust the distance the robot will travel on FTC Dashboard: 192/168/43/1:8080/dash
+ * You can adjust the distance the robot will travel on FTC Dashboard: http://192.168.43.1:8080/dash
  *
  * @author Anyi Lin - 10158 Scott's Bots
  * @author Aaron Yang - 10158 Scott's Bots


### PR DESCRIPTION
Road Runner has an op mode for debugging odometry hardware installation. The instructions for Pedro Pathing say to make sure the encoder ticks are increasing when the robot goes forward and right, but there's no easy way to check that.

This PR adds the LocalizerDirection op mode and the `debug` method to `Localizer` to show the raw output of the sensors used by the localizer.